### PR TITLE
feat: Build upf snap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: ""
+labels: ["bug"]
+assignees: ''
+---
+
+#### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+
+#### To Reproduce
+<!-- Steps that can be taken to reproduce the behaviour -->
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+#### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+#### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+#### Logs
+<!-- If applicable, add logs to help explain your problem. -->
+
+#### Environment
+
+- Snap version: <!-- e.g. 1.2 -->
+- Juju version (output from `juju --version`):
+- Cloud Environment: <!-- e.g. AWS -->
+
+#### Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore: "

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+# Description
+
+Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+# Checklist:
+
+- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that validate the behaviour of the software
+- [ ] I validated that new and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,4 @@ Please include a summary of the change. Please also include relevant motivation 
 - [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests that validate the behaviour of the software
-- [ ] I validated that new and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,39 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build snap locally
-        uses: snapcore/action-build@v1
+        uses: snapcore/action-build@v1.2.0
         id: snapcraft
-
+      
       - name: Upload locally built snap artifact
         uses: actions/upload-artifact@v4
         with:
-          name: local-${{ steps.snapcraft.outputs.snap }}
+          name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
+
+  publish:
+    name: Snap publish
+    if: ${{ github.ref_name == 'main' }}
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Downloads locally built snap artifact
+        uses: actions/download-artifact@v4
+        id: download
+        with:
+          name: snap
+
+      - name: Determine snap file name
+        id: find-snap
+        run: |
+          SNAP_FILE=$(ls *.snap)
+          echo "Found snap file: $SNAP_FILE"
+          echo "snap_file=${SNAP_FILE}" >>$GITHUB_OUTPUT
+
+      - name: publish snap
+        uses: snapcore/action-publish@v1.2.0
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.find-snap.outputs.snap_file }}
+          release: edge

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Main branch workflow
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build snap
+    runs-on: ubuntu-20.04
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build snap locally
+        uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: Upload locally built snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-${{ steps.snapcraft.outputs.snap }}
+          path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: Main branch workflow
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/telco

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+
+Install snapcraft:
+
+```bash
+sudo snap install snapcraft --classic
+```
+
+Build the snap:
+
+```bash
+snapcraft --verbose
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sdcore-upf-snap
+# SD-Core User Plane Function (UPF) Snap
 
 A snap for the SD-Core User Plane Function
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # sdcore-upf-snap
+
+A snap for the SD-Core User Plane Function
+
+## Install
+
+```bash
+sudo snap install sdcore-upf
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A snap for the SD-Core User Plane Function
 ### Install
 
 ```bash
-sudo snap install sdcore-upf
+sudo snap install sdcore-upf --edge --devmode
 ```
 
 ### Configure

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ A snap for the SD-Core User Plane Function.
 
 ### Usage
 
+Install the snap:
+```bash
+sudo snap install sdcore-upf
+sudo snap connect sdcore-upf:network-control
+sudo snap connect sdcore-upf:io-ports-control
+sudo snap connect sdcore-upf:var-run
+```
+
 Configure the UPF by editing the `/var/snap/sdcore-upf/common/upf.json` file, then start the individual services:
 * `sudo snap start sdcore-upf.routectl`
 * `sudo snap start sdcore-upf.bessd`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Start the services:
 ```bash
 sudo snap start sdcore-upf.bessd
 sudo snap start sdcore-upf.routectl
+sudo snap start sdcore-upf.pfcpiface
 ```
 
 ### Observe
@@ -30,4 +31,5 @@ Read the logs:
 ```bash
 journalctl -b --no-pager -u snap.sdcore-upf.bessd.service -f
 journalctl -b --no-pager -u snap.sdcore-upf.routectl.service -f
+journalctl -b --no-pager -u snap.sdcore-upf.pfcpiface.service -f
 ```

--- a/README.md
+++ b/README.md
@@ -4,22 +4,30 @@ A snap for the SD-Core User Plane Function
 
 ## Usage
 
-Install the snap:
+### Install
 
 ```bash
 sudo snap install sdcore-upf
 ```
 
-Configure the upf by editing the `/var/snap/sdcore-upf/common/upf.json` file.
+### Configure
 
-Start the bessd service:
+Configure the upf bessd by editing the `/var/snap/sdcore-upf/common/upf.json` file.
+
+### Start
+
+Start the services:
 
 ```bash
 sudo snap start sdcore-upf.bessd
+sudo snap start sdcore-upf.routectl
 ```
+
+### Observe
 
 Read the logs:
 
 ```bash
 journalctl -b --no-pager -u snap.sdcore-upf.bessd.service -f
+journalctl -b --no-pager -u snap.sdcore-upf.routectl.service -f
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A snap for the SD-Core User Plane Function.
 
 Install the snap:
 ```bash
-sudo snap install sdcore-upf
+sudo snap install sdcore-upf --devmode
 sudo snap connect sdcore-upf:network-control
 sudo snap connect sdcore-upf:io-ports-control
 sudo snap connect sdcore-upf:var-run

--- a/README.md
+++ b/README.md
@@ -1,35 +1,14 @@
 # SD-Core User Plane Function (UPF) Snap
 
-A snap for the SD-Core User Plane Function
+A snap for the SD-Core User Plane Function.
 
-## Usage
+### Usage
 
-### Install
+Configure the UPF by editing the `/var/snap/sdcore-upf/common/upf.json` file, then start the individual services:
+* `sudo snap start sdcore-upf.routectl`
+* `sudo snap start sdcore-upf.bessd`
+* `sudo snap start sdcore-upf.pfcpiface`
 
-```bash
-sudo snap install sdcore-upf --edge --devmode
-```
+## Reference
 
-### Configure
-
-Configure the upf bessd by editing the `/var/snap/sdcore-upf/common/upf.json` file.
-
-### Start
-
-Start the services:
-
-```bash
-sudo snap start sdcore-upf.bessd
-sudo snap start sdcore-upf.routectl
-sudo snap start sdcore-upf.pfcpiface
-```
-
-### Observe
-
-Read the logs:
-
-```bash
-journalctl -b --no-pager -u snap.sdcore-upf.bessd.service -f
-journalctl -b --no-pager -u snap.sdcore-upf.routectl.service -f
-journalctl -b --no-pager -u snap.sdcore-upf.pfcpiface.service -f
-```
+- [SD-Core](https://opennetworking.org/sd-core/)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,24 @@
 
 A snap for the SD-Core User Plane Function
 
-## Install
+## Usage
+
+Install the snap:
 
 ```bash
 sudo snap install sdcore-upf
+```
+
+Configure the upf by editing the `/var/snap/sdcore-upf/common/upf.json` file.
+
+Start the bessd service:
+
+```bash
+sudo snap start sdcore-upf.bessd
+```
+
+Read the logs:
+
+```bash
+journalctl -b --no-pager -u snap.sdcore-upf.bessd.service -f
 ```

--- a/config/upf.json
+++ b/config/upf.json
@@ -1,0 +1,47 @@
+{
+    "access": {
+        "ifname": "access"
+    },
+    "core": {
+        "ifname": "core",
+        "ip_masquerade": "192.168.250.3"
+    },
+    "cpiface": {
+        "dnn": "internet",
+        "enable_ue_ip_alloc": false,
+        "hostname": "my.hostname.com",
+        "http_port": "8080"
+    },
+    "enable_notify_bess": true,
+    "gtppsc": true,
+    "hwcksum": true,
+    "log_level": "trace",
+    "max_sessions": 50000,
+    "measure_flow": false,
+    "measure_upf": true,
+    "mode": "af_packet",
+    "notify_sockaddr": "/pod-share/notifycp",
+    "qci_qos_config": [
+        {
+            "burst_duration_ms": 10,
+            "cbs": 50000,
+            "ebs": 50000,
+            "pbs": 50000,
+            "priority": 7,
+            "qci": 0
+        }
+    ],
+    "slice_rate_limit_config": {
+        "n3_bps": 1000000000,
+        "n3_burst_bytes": 12500000,
+        "n6_bps": 1000000000,
+        "n6_burst_bytes": 12500000
+    },
+    "table_sizes": {
+        "appQERLookup": 200000,
+        "farLookup": 150000,
+        "pdrLookup": 50000,
+        "sessionQERLookup": 100000
+    },
+    "workers": 1
+}

--- a/local/patches/0001-af_packet-Avoid-set-ioctl-if-there-is-no-flag-diff.patch
+++ b/local/patches/0001-af_packet-Avoid-set-ioctl-if-there-is-no-flag-diff.patch
@@ -1,0 +1,55 @@
+SPDX-License-Identifier: Apache-2.0
+Copyright 2019 Intel Corporation
+
+From e1bc63488d346cb84ae7e76f2bc480247f577abb Mon Sep 17 00:00:00 2001
+From: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
+Date: Fri, 12 Jun 2020 21:36:53 +0000
+Subject: [PATCH] af_packet Avoid set ioctl if there is no flag diff
+
+rte_eth_dev_start -> rte_eth_dev_config_restore
+In 19.11 DPDK started returning errors
+https://github.com/DPDK/dpdk/commit/9039c8125730adfd46b8c891e7f205eb4ac43c67
+https://github.com/DPDK/dpdk/commit/69d0e7092874db1909bc40986c06219f1880dc23
+
+Gist
+https://gist.github.com/krsna1729/0c7160920343f9fa55f760c770286155
+
+We also patch af_packet PMD to change set flags only when needed
+
+Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
+---
+ drivers/net/af_packet/rte_eth_af_packet.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/net/af_packet/rte_eth_af_packet.c b/drivers/net/af_packet/rte_eth_af_packet.c
+index f5806bf42..29d45eb47 100644
+--- a/drivers/net/af_packet/rte_eth_af_packet.c
++++ b/drivers/net/af_packet/rte_eth_af_packet.c
+@@ -472,6 +472,7 @@ static int
+ eth_dev_change_flags(char *if_name, uint32_t flags, uint32_t mask)
+ {
+ 	struct ifreq ifr;
++	uint32_t cur_flags;
+ 	int ret = 0;
+ 	int s;
+
+@@ -484,8 +485,16 @@ eth_dev_change_flags(char *if_name, uint32_t flags, uint32_t mask)
+ 		ret = -errno;
+ 		goto out;
+ 	}
++
++	cur_flags = ifr.ifr_flags;
+ 	ifr.ifr_flags &= mask;
+ 	ifr.ifr_flags |= flags;
++
++	// Return if there is no change
++	if (cur_flags == ifr.ifr_flags){
++		goto out;
++	}
++
+ 	if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0) {
+ 		ret = -errno;
+ 		goto out;
+--
+2.25.1
+

--- a/local/patches/bpf_validate.patch
+++ b/local/patches/bpf_validate.patch
@@ -1,0 +1,41 @@
+diff --git a/lib/librte_bpf/bpf_impl.h b/lib/librte_bpf/bpf_impl.h
+index b577e2c..f1d6f9a 100644
+--- a/lib/librte_bpf/bpf_impl.h
++++ b/lib/librte_bpf/bpf_impl.h
+@@ -21,7 +21,7 @@ struct rte_bpf {
+ 	uint32_t stack_sz;
+ };
+ 
+-extern int bpf_validate(struct rte_bpf *bpf);
++extern int rte_bpf_validate(struct rte_bpf *bpf);
+ 
+ extern int bpf_jit(struct rte_bpf *bpf);
+ 
+diff --git a/lib/librte_bpf/bpf_load.c b/lib/librte_bpf/bpf_load.c
+index d9d163b..bd9eebf 100644
+--- a/lib/librte_bpf/bpf_load.c
++++ b/lib/librte_bpf/bpf_load.c
+@@ -115,7 +115,7 @@
+ 		return NULL;
+ 	}
+ 
+-	rc = bpf_validate(bpf);
++	rc = rte_bpf_validate(bpf);
+ 	if (rc == 0) {
+ 		bpf_jit(bpf);
+ 		if (mprotect(bpf, bpf->sz, PROT_READ) != 0)
+diff --git a/lib/librte_bpf/bpf_validate.c b/lib/librte_bpf/bpf_validate.c
+index 83983ef..12c34f0 100644
+--- a/lib/librte_bpf/bpf_validate.c
++++ b/lib/librte_bpf/bpf_validate.c
+@@ -2209,7 +2209,7 @@ struct bpf_ins_check {
+ }
+ 
+ int
+-bpf_validate(struct rte_bpf *bpf)
++rte_bpf_validate(struct rte_bpf *bpf)
+ {
+ 	int32_t rc;
+ 	struct bpf_verifier bvf;
+-- 
+

--- a/local/patches/ethdev_include.patch
+++ b/local/patches/ethdev_include.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/librte_ethdev/rte_ethdev.h b/lib/librte_ethdev/rte_ethdev.h
+index d1a593ad1..12a892339 100644
+--- a/lib/librte_ethdev/rte_ethdev.h
++++ b/lib/librte_ethdev/rte_ethdev.h
+@@ -4284,7 +4284,7 @@ __rte_experimental
+ int rte_eth_dev_hairpin_capability_get(uint16_t port_id,
+ 				       struct rte_eth_hairpin_cap *cap);
+ 
+-#include <rte_ethdev_core.h>
++#include "rte_ethdev_core.h"
+ 
+ /**
+  *
+diff --git a/lib/librte_ethdev/rte_ethdev_driver.h b/lib/librte_ethdev/rte_ethdev_driver.h
+index 99d4cd6cd..496c77fb5 100644
+--- a/lib/librte_ethdev/rte_ethdev_driver.h
++++ b/lib/librte_ethdev/rte_ethdev_driver.h
+@@ -15,7 +15,7 @@
+  *
+  */
+ 
+-#include <rte_ethdev.h>
++#include "rte_ethdev.h"
+ 
+ #ifdef __cplusplus
+ extern "C" {

--- a/service/bin/bessd-start
+++ b/service/bin/bessd-start
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (C) 2024 Canonical Ltd
+
+set -ex
+
+export PYTHONPATH="$SNAP/opt/bess/:$PYTHONPATH"
+export CONF_FILE="$SNAP_COMMON/upf.json"
+$SNAP/bin/bessd -f -grpc-url=0.0.0.0:10514 -m 0

--- a/service/bin/bessd-start
+++ b/service/bin/bessd-start
@@ -5,4 +5,5 @@ set -ex
 
 export PYTHONPATH="$SNAP/opt/bess/:$PYTHONPATH"
 export CONF_FILE="$SNAP_COMMON/upf.json"
+
 $SNAP/bin/bessd -f -grpc-url=0.0.0.0:10514 -m 0

--- a/service/bin/pfcpiface-start
+++ b/service/bin/pfcpiface-start
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Copyright (C) 2024 Canonical Ltd
+
+export CONF_FILE="$SNAP_COMMON/upf.json"
+$SNAP/bin/pfcpiface -config $CONF_FILE

--- a/service/bin/routectl-start
+++ b/service/bin/routectl-start
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (C) 2024 Canonical Ltd
+
+set -ex
+
+export PYTHONPATH="$SNAP/opt/bess/:$PYTHONPATH"
+export PYTHONUNBUFFERED=1
+
+ACCESS_INTERFACE_NAME=$(jq -r '.access.ifname' $SNAP_COMMON/upf.json)
+CORE_INTERFACE_NAME=$(jq -r '.core.ifname' $SNAP_COMMON/upf.json)
+
+$SNAP/opt/bess/bessctl/conf/route_control.py -i $ACCESS_INTERFACE_NAME $CORE_INTERFACE_NAME

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
-# Create config file
+# Copy config file
 cp "$SNAP/opt/bess/bessctl/conf/upf.json" "$SNAP_COMMON/upf.json"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+# Create config file
+cp "$SNAP/opt/bess/bessctl/conf/upf.json" "$SNAP_COMMON/upf.json"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,19 +7,34 @@ description: SD-Core User Plane Function (UPF)
 grade: stable
 confinement: devmode
 
+plugs:
+  var-run:
+    interface: system-files
+    write:
+    - /var/run/bessd.pid
+    - /run/bessd.pid
+
 apps:
   bessd:
     daemon: simple
     install-mode: disable
     command: bin/bessd-start
+    plugs:
+      - var-run
+      - io-ports-control
+      - network-control
   routectl:
     daemon: simple
     install-mode: disable
     command: bin/routectl-start
+    plugs:
+      - network-bind
   pfcpiface:
     daemon: simple
     install-mode: disable
     command: bin/pfcpiface-start
+    plugs:
+      - network-bind
 
 parts:
   xdp:
@@ -89,10 +104,9 @@ parts:
       - python3
     override-pull: |
       snapcraftctl pull
-      for file in ${SNAPCRAFT_PROJECT_DIR}/local/patches/*
-      do
-        patch -i $file -p 1
-      done
+      patch -i ${SNAPCRAFT_PROJECT_DIR}/local/patches/0001-af_packet-Avoid-set-ioctl-if-there-is-no-flag-diff.patch -p 1
+      patch -i ${SNAPCRAFT_PROJECT_DIR}/local/patches/bpf_validate.patch -p 1
+      patch -i ${SNAPCRAFT_PROJECT_DIR}/local/patches/ethdev_include.patch -p 1
     meson-parameters:
       - --buildtype=debugoptimized
       - -Dmachine=haswell

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,13 +5,17 @@ summary: SD-Core User Plane Function
 description: SD-Core User Plane Function
 
 grade: stable
-confinement: devmode
+confinement: classic
 
 apps:
   bessd:
     daemon: simple
     install-mode: disable
     command: bin/bessd-start
+  routectl:
+    daemon: simple
+    install-mode: disable
+    command: bin/routectl-start
 
 parts:
   xdp:
@@ -161,16 +165,25 @@ parts:
     override-build: |
       snapcraftctl build
       ln -srf $SNAPCRAFT_PART_INSTALL/bin/python3 $SNAPCRAFT_PART_INSTALL/bin/python
+  
+  routectl:
+    plugin: dump
+    source: https://github.com/omec-project/upf.git
+    source-type: git
+    source-commit: 7018518c17a073f155200f05ac4fd77c9ff72d21
+    source-subdir: conf
+    stage-packages:
+      - jq
+    organize:
+      "route_control.py": opt/bess/bessctl/conf/route_control.py
 
   bess-config:
     plugin: dump
     after:
       - bess
-    source: https://github.com/omec-project/upf.git
-    source-commit: 7018518c17a073f155200f05ac4fd77c9ff72d21
-    source-subdir: conf
+    source: config
     organize:
-      "*": opt/bess/bessctl/conf/
+      "upf.json": opt/bess/bessctl/conf/upf.json
 
   service-files:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,7 +43,7 @@ parts:
       - -Dmachine=haswell
       - -Ddefault_library=static
     override-build: |
-      craftctl default
+      snapcraftctl build
     prime:
       - usr/local/lib/x86_64-linux-gnu/*.so
       - usr/local/bin/cndpfwd
@@ -74,7 +74,7 @@ parts:
       - protobuf-compiler-grpc
       - python3
     override-pull: |
-      craftctl default
+      snapcraftctl pull
       for file in ${CRAFT_PROJECT_DIR}/local/patches/*
       do
         patch -i $file -p 1
@@ -153,7 +153,7 @@ parts:
     stage-packages:
       - python3-venv
     override-build: |
-      craftctl default
+      snapcraftctl build
       ln -srf $CRAFT_PART_INSTALL/bin/python3 $CRAFT_PART_INSTALL/bin/python
 
   config:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,7 +75,7 @@ parts:
       - python3
     override-pull: |
       snapcraftctl pull
-      for file in ${CRAFT_PROJECT_DIR}/local/patches/*
+      for file in ${SNAPCRAFT_PROJECT_DIR}/local/patches/*
       do
         patch -i $file -p 1
       done
@@ -156,7 +156,7 @@ parts:
       snapcraftctl build
       ln -srf $CRAFT_PART_INSTALL/bin/python3 $CRAFT_PART_INSTALL/bin/python
 
-  config:
+  bess-config:
     plugin: dump
     after:
       - bess
@@ -165,3 +165,14 @@ parts:
     source-subdir: conf
     organize:
       "*": opt/bess/bessctl/conf/
+
+  pfcpiface:
+    plugin: go
+    source: https://github.com/omec-project/upf.git
+    source-commit: 57860858a17088d06c6bc0def9fcd6e6697a1e98
+    build-snaps:
+      - go
+    stage-packages:
+      - libc6_libs
+    prime:
+      - -bin/p4info_code_gen

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,6 +173,6 @@ parts:
     build-snaps:
       - go
     stage-packages:
-      - libc6_libs
+      - libc6
     prime:
       - -bin/p4info_code_gen

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,12 +129,12 @@ parts:
         protoc "$file" --proto_path=protobuf --python_out=pybess/builtin_pb --grpc_out=pybess/builtin_pb --plugin=protoc-gen-grpc=$(which grpc_python_plugin)
       done
       make -C core bessd modules
-      mkdir -p $CRAFT_PART_INSTALL/bin
-      cp bin/bessd $CRAFT_PART_INSTALL/bin/bessd
-      mkdir -p $CRAFT_PART_INSTALL/opt/bess/bessctl
-      mkdir -p $CRAFT_PART_INSTALL/opt/bess/pybess
-      cp -r bessctl/* $CRAFT_PART_INSTALL/opt/bess/bessctl/
-      cp -r pybess/* $CRAFT_PART_INSTALL/opt/bess/pybess/
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp bin/bessd $SNAPCRAFT_PART_INSTALL/bin/bessd
+      mkdir -p $SNAPCRAFT_PART_INSTALL/opt/bess/bessctl
+      mkdir -p $SNAPCRAFT_PART_INSTALL/opt/bess/pybess
+      cp -r bessctl/* $SNAPCRAFT_PART_INSTALL/opt/bess/bessctl/
+      cp -r pybess/* $SNAPCRAFT_PART_INSTALL/opt/bess/pybess/
 
   bess-python-deps:
     plugin: python
@@ -154,7 +154,7 @@ parts:
       - python3-venv
     override-build: |
       snapcraftctl build
-      ln -srf $CRAFT_PART_INSTALL/bin/python3 $CRAFT_PART_INSTALL/bin/python
+      ln -srf $SNAPCRAFT_PART_INSTALL/bin/python3 $SNAPCRAFT_PART_INSTALL/bin/python
 
   bess-config:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,11 @@
 name: sdcore-upf
 base: core20
 version: '1.3'
-summary: SD-Core User Plane Function
-description: SD-Core User Plane Function
+summary: SD-Core UPF
+description: SD-Core User Plane Function (UPF)
 
 grade: stable
-confinement: classic
+confinement: devmode
 
 apps:
   bessd:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,167 @@
+name: sdcore-upf
+base: core20
+version: '1.3'
+summary: SD-Core User Plane Function
+description: SD-Core User Plane Function
+
+grade: devel
+confinement: devmode
+
+parts:
+  xdp:
+    plugin: autotools
+    source: https://github.com/xdp-project/xdp-tools.git
+    source-tag: v1.2.2
+    build-packages:
+      - clang
+      - gcc-multilib
+      - libelf-dev
+      - libpcap-dev
+      - linux-headers-5.4.0-26
+      - llvm
+    prime:
+      - usr/local/lib/x86_64-linux-gnu/*.so
+      - usr/lib/libxdp*
+
+  cndp:
+    after:
+      - xdp
+    plugin: meson
+    source: https://github.com/CloudNativeDataPlane/cndp.git
+    source-commit: d5ce4b9edc2e7ddb46a61b395deffafaf11a0500
+    build-packages:
+      - clang
+      - golang
+      - libbpf-dev
+      - libbsd-dev
+      - libnl-3-dev
+      - libnl-cli-3-dev
+      - libnuma-dev
+      - lld
+    meson-parameters:
+      - -Dbuildtype=release
+      - -Dmachine=haswell
+      - -Ddefault_library=static
+    override-build: |
+      craftctl default
+    prime:
+      - usr/local/lib/x86_64-linux-gnu/*.so
+      - usr/local/bin/cndpfwd
+
+  dpdk:
+    plugin: meson
+    after:
+      - cndp
+    source: https://fast.dpdk.org/rel/dpdk-20.11.3.tar.gz
+    source-type: tar
+    build-packages:
+      - ca-certificates
+      - libbenchmark-dev
+      - libbpf0
+      - libc-ares-dev
+      - libelf-dev
+      - libgflags2.2
+      - libgoogle-glog-dev
+      - libgrpc++-dev
+      - libgtest-dev
+      - libjson-c-dev
+      - libnuma-dev
+      - libpcap-dev
+      - libprotobuf-dev
+      - libunwind-dev
+      - meson
+      - protobuf-compiler
+      - protobuf-compiler-grpc
+      - python3
+    override-pull: |
+      craftctl default
+      for file in ${CRAFT_PROJECT_DIR}/local/patches/*
+      do
+        patch -i $file -p 1
+      done
+    meson-parameters:
+      - --buildtype=debugoptimized
+      - -Dmachine=haswell
+    prime:
+      - usr/local/lib/x86_64-linux-gnu/*.so
+
+  bess:
+    plugin: nil
+    after:
+      - dpdk
+    source: https://github.com/omec-project/bess.git
+    source-tag: dpdk-2011-focal
+    source-type: git
+    build-packages:
+      - ca-certificates
+      - libbenchmark-dev
+      - libbpf0
+      - libc-ares-dev
+      - libelf-dev
+      - libgflags2.2
+      - libgoogle-glog-dev
+      - libgrpc++-dev
+      - libgtest-dev
+      - libjson-c-dev
+      - libnuma-dev
+      - libpcap-dev
+      - libprotobuf-dev
+      - libssl-dev
+      - libunwind-dev
+      - meson
+      - pkg-config
+      - protobuf-compiler
+      - protobuf-compiler-grpc
+      - python3
+    stage-packages:
+      - libbpf0
+      - libgflags2.2
+      - libjson-c4
+      - libgraph-easy-perl
+      - iproute2
+      - iptables
+      - iputils-ping
+      - tcpdump
+      - ethtool
+    override-build: |
+      for file in $(find ./protobuf -name *.proto -print)
+      do
+        protoc "$file" --proto_path=protobuf --python_out=pybess/builtin_pb --grpc_out=pybess/builtin_pb --plugin=protoc-gen-grpc=$(which grpc_python_plugin)
+      done
+      make -C core bessd modules
+      mkdir -p $CRAFT_PART_INSTALL/bin
+      cp bin/bessd $CRAFT_PART_INSTALL/bin/bessd
+      mkdir -p $CRAFT_PART_INSTALL/opt/bess/bessctl
+      mkdir -p $CRAFT_PART_INSTALL/opt/bess/pybess
+      cp -r bessctl/* $CRAFT_PART_INSTALL/opt/bess/bessctl/
+      cp -r pybess/* $CRAFT_PART_INSTALL/opt/bess/pybess/
+
+  bess-python-deps:
+    plugin: python
+    after:
+      - bess
+    source: .
+    python-packages:
+      - flask
+      - grpcio
+      - iptools
+      - mitogen
+      - protobuf==3.20.0
+      - psutil
+      - pyroute2
+      - scapy
+    stage-packages:
+      - python3-venv
+    override-build: |
+      craftctl default
+      ln -srf $CRAFT_PART_INSTALL/bin/python3 $CRAFT_PART_INSTALL/bin/python
+
+  config:
+    plugin: dump
+    after:
+      - bess
+    source: https://github.com/omec-project/upf.git
+    source-commit: 7018518c17a073f155200f05ac4fd77c9ff72d21
+    source-subdir: conf
+    organize:
+      "*": opt/bess/bessctl/conf/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,10 @@ apps:
     daemon: simple
     install-mode: disable
     command: bin/routectl-start
+  pfcpiface:
+    daemon: simple
+    install-mode: disable
+    command: bin/pfcpiface-start
 
 parts:
   xdp:
@@ -188,3 +192,12 @@ parts:
   service-files:
     plugin: dump
     source: service
+
+  pfcpiface:
+    plugin: go
+    source: https://github.com/omec-project/upf.git
+    source-commit: 57860858a17088d06c6bc0def9fcd6e6697a1e98
+    build-snaps:
+      - go
+    prime:
+      - -bin/p4info_code_gen

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,8 +4,14 @@ version: '1.3'
 summary: SD-Core User Plane Function
 description: SD-Core User Plane Function
 
-grade: devel
+grade: stable
 confinement: devmode
+
+apps:
+  bessd:
+    daemon: simple
+    install-mode: disable
+    command: bin/bessd-start
 
 parts:
   xdp:
@@ -166,13 +172,6 @@ parts:
     organize:
       "*": opt/bess/bessctl/conf/
 
-  pfcpiface:
-    plugin: go
-    source: https://github.com/omec-project/upf.git
-    source-commit: 57860858a17088d06c6bc0def9fcd6e6697a1e98
-    build-snaps:
-      - go
-    stage-packages:
-      - libc6
-    prime:
-      - -bin/p4info_code_gen
+  service-files:
+    plugin: dump
+    source: service


### PR DESCRIPTION
# Description

Builds base snap, very much taking from the existing upf [bessd](https://github.com/canonical/sdcore-upf-pfcpiface-rock) and [pfcpiface](https://github.com/canonical/sdcore-upf-pfcpiface-rock) ROCK's.

## Usage

### Install

```bash
sudo snap install sdcore-upf
```

### Configure

Configure the upf bessd by editing the `/var/snap/sdcore-upf/common/upf.json` file.

### Run

Start the snap services:

```bash
sudo snap start sdcore-upf.bessd
sudo snap start sdcore-upf.routectl
sudo snap start sdcore-upf.pfcpiface
```

### Observe

Read the logs:

```bash
journalctl -b --no-pager -u snap.sdcore-upf.bessd.service -f
journalctl -b --no-pager -u snap.sdcore-upf.routectl.service -f
journalctl -b --no-pager -u snap.sdcore-upf.pfcpiface.service -f
```