### PR TITLE
fix: Remove strict confinement from bessd

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,22 +7,11 @@ description: SD-Core User Plane Function (UPF)
 grade: stable
 confinement: devmode
 
-plugs:
-  var-run:
-    interface: system-files
-    write:
-    - /var/run/bessd.pid
-    - /run/bessd.pid
-
 apps:
   bessd:
     daemon: simple
     install-mode: disable
     command: bin/bessd-start
-    plugs:
-      - var-run
-      - io-ports-control
-      - network-control
   routectl:
     daemon: simple
     install-mode: disable


### PR DESCRIPTION
# Description

Remove strict confinement from bessd because it causes the publish step to fail with the following error. There's no need to have those plugs anyway as currently the charm is only available in devmode. We should go through the reivew process once we figure strict confinement for this charm.

```
human review required due to 'allow-installation' constraint (bool) declaration-snap-v2_plugs_installation (var-run, system-files)
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
