### PR TITLE
feat: add app for bessctl

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,10 @@ apps:
     command: bin/pfcpiface-start
     plugs:
       - network-bind
+  bessctl:
+    command: opt/bess/bessctl/bessctl
+    environment:
+      CONF_FILE: /var/snap/sdcore-upf/common/upf.json
 
 parts:
   xdp:


### PR DESCRIPTION
# Description

We add a snapcraft app for `bessctl` that will be used in the `sdcore-upf` charm. 

Ex:
```shell
sdcore-upf.bessctl run /snap/sdcore-upf/current/up4
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
