### PR TITLE
fix: Use Upstream tag instead of commit id

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -212,7 +212,7 @@ parts:
     after:
       - bess
     source: https://github.com/omec-project/upf.git
-    source-commit: e52a4f2a6ba53467aa9e13a36a473d680bd5c61a
+    source-tag: v1.4.0
     source-subdir: conf
     organize:
       "*": opt/bess/bessctl/conf/


### PR DESCRIPTION
# Description

snapcraft.yaml uses an old commit id of https://github.com/omec-project/upf.git which does not include the  patch https://github.com/omec-project/upf/pull/782. So, bug https://github.com/omec-project/upf/issues/779 still appears when we install sdcore-upf-charm. Besides, we need to start to use tags instead of commit ID's.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
