### PR TITLE
chore: publish to 1.4/edge instead of latest/edge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
+
       - name: Downloads locally built snap artifact
         uses: actions/download-artifact@v4
         id: download
@@ -52,7 +53,7 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         with:
           snap: ${{ steps.find-snap.outputs.snap_file }}
-          release: edge
+          release: 1.4/edge
 
       - name: Publish developer snap to branch
         uses: snapcore/action-publish@v1.2.0
@@ -61,4 +62,4 @@ jobs:
         if: ${{ (github.ref_name != 'main') && (github.event_name == 'push') }}
         with:
           snap: ${{ steps.find-snap.outputs.snap_file }}
-          release: latest/edge/${{ github.ref_name }}
+          release: 1.4/edge/${{ github.ref_name }}


### PR DESCRIPTION
# Description

Now that we have a `1.4` track for the upf snap, we publish to it instead of `latest`.

## Reference
- https://forum.snapcraft.io/t/create-a-1-4-track-for-the-sd-core-upf-snap/39673/2

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
