### PR TITLE
chore: change confinement to classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A snap for the SD-Core User Plane Function.
 
 Install the snap:
 ```bash
-sudo snap install sdcore-upf --devmode
+sudo snap install sdcore-upf --classic
 sudo snap connect sdcore-upf:network-control
 sudo snap connect sdcore-upf:io-ports-control
 sudo snap connect sdcore-upf:var-run

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -206,10 +206,13 @@ parts:
       - psutil
       - pyroute2
       - scapy
+    build-packages:
+      - python3-dev
+      - python3-venv
     stage-packages:
       - python3-venv
     override-build: |
-      snapcraftctl build
+      craftctl default
       ln -srf $SNAPCRAFT_PART_INSTALL/bin/python3 $SNAPCRAFT_PART_INSTALL/bin/python
 
   config:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ description: |
 
 icon: icon.svg
 grade: stable
-confinement: devmode
+confinement: classic
 license: Apache-2.0
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -206,11 +206,9 @@ parts:
       - psutil
       - pyroute2
       - scapy
-    build-packages:
-      - python3-dev
-      - python3-venv
     stage-packages:
       - python3-venv
+      - python3.10-minimal
     override-build: |
       craftctl default
       ln -srf $SNAPCRAFT_PART_INSTALL/bin/python3 $SNAPCRAFT_PART_INSTALL/bin/python


### PR DESCRIPTION
# Description

Change snap confinement to classic to be able to publish to stable and have the charm under the Canonical namespace.

Request to change the confinement from `devmode` to `classic` in the snap store:
- https://forum.snapcraft.io/t/change-sd-core-upf-snap-confinement-to-classic/40459

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
