### PR TITLE
fix: replace snapcraftctl with craftctl

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -209,7 +209,7 @@ parts:
     stage-packages:
       - python3-venv
     override-build: |
-      snapcraftctl build
+      craftctl default
       ln -srf $SNAPCRAFT_PART_INSTALL/bin/python3 $SNAPCRAFT_PART_INSTALL/bin/python
 
   config:


### PR DESCRIPTION
# Description

Replace snapcraftctl with craftctl to fix the snap build.

## Logs

```
:: Traceback (most recent call last):
::   File "/snap/snapcraft/current/lib/python3.10/site-packages/craft_parts/ctl.py", line 111, in main
::     ret = CraftCtl.run(cmd, args)
::   File "/snap/snapcraft/current/lib/python3.10/site-packages/craft_parts/ctl.py", line 45, in run
::     _client(cmd, args)
::   File "/snap/snapcraft/current/lib/python3.10/site-packages/craft_parts/ctl.py", line 98, in _client
::     raise RuntimeError(message)
:: RuntimeError: Failed to run the build script for part 'bess-python-deps'.
'override-build' in part 'bess-python-deps' failed with code 1.
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
