### PR TITLE
chore: bump upf to 1.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         with:
           snap: ${{ steps.find-snap.outputs.snap_file }}
-          release: 1.4/edge
+          release: 1.5/edge
 
       - name: Publish developer snap to branch
         uses: snapcore/action-publish@v1.2.0
@@ -62,4 +62,4 @@ jobs:
         if: ${{ (github.ref_name != 'main') && (github.event_name == 'push') }}
         with:
           snap: ${{ steps.find-snap.outputs.snap_file }}
-          release: 1.4/edge/${{ github.ref_name }}
+          release: 1.5/edge/${{ github.ref_name }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: sdcore-upf
 base: core22
-version: '1.4.0'
+version: '1.5.0'
 summary: SD-Core User Plane Function (UPF)
 description: |
   This project implements a 4G/5G User Plane Function (UPF) compliant with 3GPP TS23.501.
@@ -218,7 +218,7 @@ parts:
     after:
       - bess
     source: https://github.com/omec-project/upf.git
-    source-tag: v1.4.0
+    source-tag: v1.5.0
     source-subdir: conf
     organize:
       "*": opt/bess/bessctl/conf/
@@ -236,7 +236,7 @@ parts:
   pfcpiface:
     plugin: go
     source: https://github.com/omec-project/upf.git
-    source-tag: v1.4.0
+    source-tag: v1.5.0
     build-snaps:
       - go
     prime:


### PR DESCRIPTION
# Description

Bump upf to 1.5.0.

Before merging this PR:
- [x] Crate a new `1.5` track in snapcraft
  - In progress: https://forum.snapcraft.io/t/create-new-track-for-sdcore-upf/43434 
- [ ] Create a new `1.4` git branch

## Reference
- https://github.com/omec-project/upf/releases/tag/v1.5.0

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
